### PR TITLE
do not advance based on file size

### DIFF
--- a/index.js
+++ b/index.js
@@ -198,8 +198,8 @@ Reader.prototype.createStream = function () {
           logger.error('lines@EOF: ' + slr.linesAtEndOfFile);
           logger.error('mark.lines: ' + mark.lines);
         }
-        logger.info('\tbytes.start: ' + mark.size);
-        fileOpts.start = mark.size;
+        // logger.info('\tbytes.start: ' + mark.size);
+        // fileOpts.start = mark.size;
         slr.sawEndOfFile = false;
         slr.lines.position = mark.lines;
       }


### PR DESCRIPTION
until a safe way that avoids race conditions is found.

fixes #17 
